### PR TITLE
add: データベース定義（ddl.sql）を追加

### DIFF
--- a/docs/er-diagram.drawio
+++ b/docs/er-diagram.drawio
@@ -1,22 +1,25 @@
 <mxfile host="65bd71144e">
     <diagram id="xKbMBg5VAx2Vo-qnaRjD" name="ページ1">
-        <mxGraphModel dx="933" dy="552" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="593" dy="400" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
                 <mxCell id="15" value="users" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
-                    <mxGeometry x="80" y="260" width="160" height="116" as="geometry"/>
+                    <mxGeometry x="80" y="260" width="160" height="146" as="geometry"/>
                 </mxCell>
-                <mxCell id="16" value="spotify_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="15">
+                <mxCell id="76" value="id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="15">
                     <mxGeometry y="26" width="160" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="17" value="display_name" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="15">
+                <mxCell id="16" value="spotify_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="15">
                     <mxGeometry y="56" width="160" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="19" value="created_at" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="15">
+                <mxCell id="17" value="display_name" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="15">
                     <mxGeometry y="86" width="160" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="20" value="recomendations" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
+                <mxCell id="19" value="created_at" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="15">
+                    <mxGeometry y="116" width="160" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="recommendation" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
                     <mxGeometry x="310" y="260" width="160" height="146" as="geometry"/>
                 </mxCell>
                 <mxCell id="21" value="id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="20">
@@ -32,7 +35,7 @@
                     <mxGeometry y="116" width="160" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="24" value="favorites" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" vertex="1" parent="1">
-                    <mxGeometry x="80" y="430" width="160" height="146" as="geometry"/>
+                    <mxGeometry x="80" y="445" width="160" height="146" as="geometry"/>
                 </mxCell>
                 <mxCell id="25" value="id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;whiteSpace=wrap;html=1;" vertex="1" parent="24">
                     <mxGeometry y="26" width="160" height="30" as="geometry"/>
@@ -126,7 +129,9 @@
                     <mxGeometry x="-1" relative="1" as="geometry"/>
                 </mxCell>
                 <mxCell id="68" value="*" style="edgeLabel;resizable=0;html=1;align=right;verticalAlign=bottom;" connectable="0" vertex="1" parent="66">
-                    <mxGeometry x="1" relative="1" as="geometry"/>
+                    <mxGeometry x="1" relative="1" as="geometry">
+                        <mxPoint y="-1" as="offset"/>
+                    </mxGeometry>
                 </mxCell>
                 <mxCell id="69" value="" style="endArrow=none;html=1;" edge="1" parent="1" source="28" target="34">
                     <mxGeometry relative="1" as="geometry">
@@ -135,7 +140,9 @@
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="70" value="1" style="edgeLabel;resizable=0;html=1;align=left;verticalAlign=bottom;" connectable="0" vertex="1" parent="69">
-                    <mxGeometry x="-1" relative="1" as="geometry"/>
+                    <mxGeometry x="-1" relative="1" as="geometry">
+                        <mxPoint y="-11" as="offset"/>
+                    </mxGeometry>
                 </mxCell>
                 <mxCell id="71" value="*" style="edgeLabel;resizable=0;html=1;align=right;verticalAlign=bottom;" connectable="0" vertex="1" parent="69">
                     <mxGeometry x="1" relative="1" as="geometry">
@@ -149,6 +156,15 @@
                     <mxGeometry width="50" height="50" relative="1" as="geometry">
                         <mxPoint x="460" y="520" as="sourcePoint"/>
                         <mxPoint x="510" y="470" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="77" value="spotify_id は&lt;div&gt;Spotify APIとの&lt;span style=&quot;background-color: transparent;&quot;&gt;連携用に&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;background-color: transparent;&quot;&gt;保持しておく外部ID。&lt;/span&gt;&lt;div&gt;&lt;br&gt;&lt;div&gt;内部のリレーションや参照には&lt;/div&gt;&lt;div&gt;自前の id（主キー）を使用する。&lt;/div&gt;&lt;/div&gt;&lt;/div&gt;" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;darkOpacity=0.05;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+                    <mxGeometry x="130" y="90" width="190" height="111" as="geometry"/>
+                </mxCell>
+                <mxCell id="78" value="" style="endArrow=none;dashed=1;html=1;" edge="1" parent="1" target="77" source="15">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="200" y="70" as="sourcePoint"/>
+                        <mxPoint x="240" y="-9" as="targetPoint"/>
                     </mxGeometry>
                 </mxCell>
             </root>

--- a/infra/ddl.sql
+++ b/infra/ddl.sql
@@ -1,0 +1,35 @@
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY, 
+    spotify_id TEXT UNIQUE NOT NULL,
+    display_name TEXT NOT NULL DEFAULT 'user',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE tracks (
+    id SERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    spotify_track_id TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP 
+);
+
+CREATE TABLE recommendations (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    seed_track_id INTEGER NOT NULL REFERENCES tracks(id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE recommendation_tracks (
+    id SERIAL PRIMARY KEY,
+    recommendation_id INTEGER NOT NULL REFERENCES recommendations(id),
+    track_id INTEGER NOT NULL REFERENCES tracks(id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE favorites (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    track_id INTEGER NOT NULL REFERENCES tracks(id),
+    UNIQUE (user_id, track_id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)


### PR DESCRIPTION
## 概要  
digbeats-v2で使用するリレーショナルDBのDDL（テーブル定義）を作成しました。  
ER図をもとに、アプリの主要なデータ構造と関連をPostgreSQL用SQLで定義しています。

## 主な変更  
- `infra/ddl.sql` を追加
- 以下のテーブルを定義：
  - `users`: Spotify連携ユーザー情報（内部ID＋Spotify ID）
  - `tracks`: 楽曲情報（Spotify Track ID含む）
  - `recommendations`: レコメンド履歴（ユーザー＋シード曲）
  - `recommendation_tracks`: レコメンド結果（1回のレコメンドに複数曲）
  - `favorites`: お気に入り登録（ユーザーと曲の中間テーブル、重複防止）

## 補足  
- `created_at` を全テーブルに追加し、履歴・ソート・分析などに対応  
- 外部キーにはすべて `NOT NULL` を指定し、リレーションの整合性を強化  
- 今後Supabase上でこのDDLを実行し、DB構築 → API設計に進みます。
