### PR TITLE
add: OpenAPI仕様書（openeapi.yaml）を作成

### DIFF
--- a/docs/openapi-draft.md
+++ b/docs/openapi-draft.md
@@ -91,14 +91,16 @@ GET /api/recommendations/history
 レスポンスボディ
 
 ```json
-{
-  "track_name": "楽曲名",
-  "artist_name": "アーティスト名",
-  "preview_url": "プレビュー音源URL",
-  "album_image": "アルバム画像",
-  "artist_image": "アーティスト画像",
-  "isLiked": "boolean"
-}
+[
+  {
+    "track_name": "楽曲名",
+    "artist_name": "アーティスト名",
+    "preview_url": "プレビュー音源URL",
+    "album_image": "アルバム画像",
+    "artist_image": "アーティスト画像",
+    "isLiked": "boolean"
+  }
+]
 ```
 
 ### お気に入り一覧を取得する
@@ -109,12 +111,14 @@ GET /api/favorites
 レスポンスボディ
 
 ```json
-{
-  "track_name": "楽曲名",
-  "artist_name": "アーティスト名",
-  "preview_url": "プレビュー音源URL",
-  "album_image": "アルバム画像",
-  "artist_image": "アーティスト画像",
-  "isLiked": "boolean"
-}
+[
+  {
+    "track_name": "楽曲名",
+    "artist_name": "アーティスト名",
+    "preview_url": "プレビュー音源URL",
+    "album_image": "アルバム画像",
+    "artist_image": "アーティスト画像",
+    "isLiked": "boolean"
+  }
+]
 ````

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,144 @@
+openapi: 3.0.3
+
+info:
+  title: digbeats API
+  version: 1.0.0
+
+paths:
+  /api/recommendations:
+    # 本来はGETメソッドだがrequestBodyを使いたいのでPOSTメソッドに変更
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                track_name:
+                  type: string
+                  example: 夜に駆ける
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  seed_track_name:
+                    type: string
+                    example: 夜に駆ける
+                  recommendedTracks:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        track_name:
+                          type: string
+                          example: 怪物
+                        artist_name:
+                          type: string
+                          example: YOASOBI
+                        preview_url:
+                          type: string
+                          format: uri
+                          example: https://xxx.co/xxx.mp3
+                        album_image:
+                          type: string
+                          format: uri
+                          example: https://xxx.co/image/xxx.jpg
+                        artist_image:
+                          type: string
+                          format: uri
+                          example: https://xxx.co/image/xxx.jpg
+
+  /api/favorites/{track_id}:
+    post:
+      parameters:
+        - name: track_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        201:
+          description: Create
+    delete:
+      parameters:
+        - name: track_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+
+  /api/recommendations/history:
+    get:
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    track_name:
+                      type: string
+                      example: 怪物
+                    artist_name:
+                      type: string
+                      example: YOASOBI
+                    preview_url:
+                      type: string
+                      format: uri
+                      example: https://xxx.co/xxx.mp3
+                    album_image:
+                      type: string
+                      format: uri
+                      example: https://xxx.co/image/xxx.jpg
+                    artist_image:
+                      type: string
+                      format: uri
+                      example: https://xxx.co/image/xxx.jpg
+                    isLiked:
+                      type: boolean
+                      example: false
+
+  /api/favorites:
+    get:
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    track_name:
+                      type: string
+                      example: 怪物
+                    artist_name:
+                      type: string
+                      example: YOASOBI
+                    preview_url:
+                      type: string
+                      format: uri
+                      example: https://xxx.co/xxx.mp3
+                    album_image:
+                      type: string
+                      format: uri
+                      example: https://xxx.co/image/xxx.jpg
+                    artist_image:
+                      type: string
+                      format: uri
+                      example: https://xxx.co/image/xxx.jpg
+                    isLiked:
+                      type: boolean
+                      example: false


### PR DESCRIPTION
## 概要  
digbeats-v2で使用するAPIの仕様書（OpenAPI YAML）を作成しました。  
recommendationsとfavoritesに関する基本的なエンドポイントを中心に、YAML形式で記述しています。

## 主な変更  
- openapi/api.yaml を新規追加（OpenAPI 3.0.3 形式）
- `/api/recommendations`：POSTメソッドでtrack_nameを受け取り、レコメンドを返す
- `/api/recommendations/history`：GETメソッドで履歴一覧を返す
- `/api/favorites`：お気に入り一覧を取得
- `/api/favorites/{track_id}`：お気に入り追加/削除（POST/DELETE）
- 日本語入力や検索文字列に対応するため、recommendationsはGETではなくPOSTに設定

## 補足  
- Swagger EditorおよびVSCodeのSwagger Viewerでプレビュー確認済み
- `openapi: 3.1.0` はプレビュー非対応のため `3.0.3` にダウングレードして対応