### PR TITLE
検索APIの初期実装（Spotify 検索機能を使用）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env.local

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,6 +49,47 @@ app.use(morgan("dev"));
 app.use(express.json());
 
 // 処理
+// キーワード検索API
+app.post(
+  "/api/search",
+  asyncHandler(async (req, res: any) => {
+    // キーワードとアクセストークンを取得
+    const keyword = req.body.keyword;
+    const accessToken = await getToken();
+
+    // キーワード検索
+    const searchResult = await axios.get(
+      `${SPOTIFY_API_BASE_URL}/search?q=${encodeURIComponent(
+        keyword
+      )}&type=track&limit=5`,
+      {
+        headers: {
+          Authorization: "Bearer " + accessToken,
+        },
+      }
+    );
+
+    const items = searchResult.data.tracks.items;
+    if (!items || items.length === 0) {
+      return res.status(404).json({ message: "曲が見つかりませんでした" });
+    }
+
+    const tracksInfo = items.map((item) => {
+      const trackName = item.name;
+
+      const artists = item.artists;
+      const artistsName = artists.map((artist) => artist.name);
+
+      return `
+      trackName: ${trackName}
+      artistsName: ${artistsName}
+      `;
+    });
+
+    return res.status(200).json({ tracksInfo });
+  })
+);
+
 // レコメンドAPI
 app.post(
   "/api/recommendations",


### PR DESCRIPTION
## 概要

Spotify の検索API `/api/search` を初期実装しました。
キーワードから5件までの楽曲情報を取得する機能です。

## 実装内容

### ✅ 機能追加（feat）

- POST `/api/search`
  - キーワードを受け取り、Spotify API で `track` を検索
  - トラック名・アーティスト名をセットで最大5件まで取得

- Spotifyの client_credentials フローでアクセストークンを取得

## 今後の方針

- `/api/recommendations` の実装を開始予定（フロントが検索APIのレスポンスから楽曲を選択、選択された trackId / artistId をフロントから受け取って処理）
- レスポンス構造やデータ取得範囲の改善
- ER図 / OpenAPI への反映

## その他

- 今回はとりあえず `index.ts` に実装していますが、今後サービス層などへの切り出しを検討します。
