### PR TITLE
Spotify APIのgetRecommendationsで一時実装 → API制限によりLast.fm APIへの方針転換

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -76,14 +76,11 @@ app.post(
 
     const tracksInfo = items.map((item) => {
       const trackName = item.name;
+      const trackId = item.id;
+      const artistsName = item.artists.map((artist) => artist.name);
+      const artistsId = item.artists.map((artist) => artist.id);
 
-      const artists = item.artists;
-      const artistsName = artists.map((artist) => artist.name);
-
-      return `
-      trackName: ${trackName}
-      artistsName: ${artistsName}
-      `;
+      return `trackName: ${trackName},trackId: ${trackId}, artistsName: ${artistsName}, artistsId: ${artistsId}`;
     });
 
     return res.status(200).json({ tracksInfo });
@@ -94,57 +91,48 @@ app.post(
 app.post(
   "/api/recommendations",
   asyncHandler(async (req, res: any) => {
-    // キーワードとアクセストークンを取得
-    const keyword = req.body.seed;
+    // 楽曲情報とアクセストークンを取得
+    const seedTrackId = req.body.trackId;
+    const seedArtistId = req.body.artistId;
     const accessToken = await getToken();
 
-    // シード曲ID を取得
-    const getSeedResult = await axios.get(
-      `${SPOTIFY_API_BASE_URL}/search?q=${encodeURIComponent(
-        keyword
-      )}&type=track&limit=1`,
-      {
-        headers: {
-          Authorization: "Bearer " + accessToken,
-        },
-      }
-    );
-    const items = getSeedResult.data.tracks.items;
-    if (!items || items.length === 0) {
-      return res.status(404).json({ message: "曲が見つかりませんでした" });
+    // TODO: seedTrackId が tracks テーブルに存在しなければ、挿入する
+
+    // TODO: seedTrackId を favorites テーブルに自動追加する（user_id, track_id）
+
+    // レコメンド一覧を取得
+    const artistParam = encodeURIComponent(seedArtistId);
+    const trackParam = encodeURIComponent(seedTrackId);
+    const url = `${SPOTIFY_API_BASE_URL}/recommendations?seed_tracks=${trackParam}`;
+    console.log(`デバッグ用！！！！！！！ url: ${url}`); //デバッグ
+    const getRecommendationsResult = await axios.get(url, {
+      headers: {
+        Authorization: "Bearer " + accessToken,
+      },
+    });
+
+    const tracks = getRecommendationsResult.data.tracks;
+    if (!tracks || tracks.length === 0) {
+      return res
+        .status(404)
+        .json({ message: "おすすめ楽曲が見つかりませんでした" });
     }
-    const seedTrackId = items[0].id;
-    const seedArtistId = items[0].artists[0].id;
-    console.log("🌱 track ID:", seedTrackId);
-    console.log("🎤 artist ID:", seedArtistId);
-    console.log(
-      "📡 URL:",
-      `${SPOTIFY_API_BASE_URL}/recommendations?seed_artists=${seedArtistId}&seed_tracks=${seedTrackId}`
-    );
 
-    // TODO: 該当の曲が tracks テーブルに存在しなければ、挿入する
-
-    // TODO: seed_track を favorites テーブルに自動追加する（user_id, track_id）
-
-    // レコメンド曲一覧を取得
-    const getRecommendationResult = await axios.get(
-      `${SPOTIFY_API_BASE_URL}/recommendations?seed_artists=${seedArtistId}&seed_tracks=${seedTrackId}`,
-      {
-        headers: {
-          Authorization: "Bearer " + accessToken,
-        },
-      }
-    );
-    const tracks = getRecommendationResult.data.tracks;
+    const tracksInfo = tracks.map((track) => {
+      const trackName = track.name;
+      const artistsName = track.artists.map((artist) => artist.name);
+      return `
+      trackName: ${trackName}
+      artistsName: ${artistsName}
+      `;
+    });
 
     // TODO: tracks テーブルに存在しないものは全て tracks テーブルに保存
 
     // TODO: recommendations テーブルに記録（user_id, seed_track_id, created_at）
 
-    // レコメンド曲一覧を返す
-    return res.json({
-      tracks: tracks.map((track) => track.name),
-    });
+    // レコメンド一覧を返す
+    return res.status(200).json({ tracksInfo });
   })
 );
 


### PR DESCRIPTION

## 概要  
Spotify Web API の `getRecommendations` を使ってレコメンド機能を一通り実装しましたが、  
2024年11月以降の新規アプリではこのエンドポイントが使用不可となっており、実行時に `403 Forbidden` が返される状態です。

そのため、本PRではSpotifyベースでのレコメンド処理の実装を記録として残しつつ、  
今後は Last.fm API へ切り替えて再実装を行う方針に変更します。

## 主な変更  
- `/api/recommendations`：Spotifyの `getRecommendations` を使用した楽曲レコメンドを一時的に実装（現在403エラー）

## 補足  
- Spotify公式の仕様変更により、新規クライアントでは `getRecommendations` エンドポイントが使用できない状況（2024年11月27日発表）  
  → 参考: [https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api](https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api)

- 今後は Last.fm API に切り替えて `track.getSimilar` を利用する 